### PR TITLE
pipeline: outputs: chronicle: fix typos and make minor wording adjustments

### DIFF
--- a/pipeline/outputs/chronicle.md
+++ b/pipeline/outputs/chronicle.md
@@ -2,7 +2,7 @@
 
 # Chronicle
 
-The Chronicle output plugin allows ingesting security logs into [Google Chronicle](https://chronicle.security/) serivice. This connector is designed to send unstructured style of security logs.
+The Chronicle output plugin allows ingesting security logs into [Google Chronicle](https://chronicle.security/) service. This connector is designed to send unstructured security logs.
 
 ## Google Cloud Configuration
 
@@ -16,11 +16,11 @@ To stream security logs into Google Chronicle, the first step is to create a Goo
 
 ### Creating a Tenant of Google Chronicle
 
-Fluent Bit does not create a tenant of Google Chronicle for your secutiry logs, so you must create this ahead of time.
+Fluent Bit does not create a tenant of Google Chronicle for your security logs, so you must create this ahead of time.
 
 ### Retrieving Service Account Credentials
 
-Fluent Bit Chronicle output plugin uses a JSON credentials file for authentication credentials. Download the credentials file by following these instructions:
+Fluent Bit's Chronicle output plugin uses a JSON credentials file for authentication credentials. Download the credentials file by following these instructions:
 
 * [Creating and Managing Service Account Keys](https://cloud.google.com/iam/docs/creating-managing-service-account-keys)
 
@@ -29,15 +29,15 @@ Fluent Bit Chronicle output plugin uses a JSON credentials file for authenticati
 | Key | Description | default |
 | :--- | :--- | :--- |
 | google\_service\_credentials | Absolute path to a Google Cloud credentials JSON file. | Value of the environment variable _$GOOGLE\_SERVICE\_CREDENTIALS_ |
-| service\_account\_email | Account email associated to the service. Only available if **no credentials file** has been provided. | Value of environment variable _$SERVICE\_ACCOUNT\_EMAIL_ |
+| service\_account\_email | Account email associated with the service. Only available if **no credentials file** has been provided. | Value of environment variable _$SERVICE\_ACCOUNT\_EMAIL_ |
 | service\_account\_secret | Private key content associated with the service account. Only available if **no credentials file** has been provided. | Value of environment variable _$SERVICE\_ACCOUNT\_SECRET_ |
 | project\_id | The project id containing the tenant of Google Chronicle to stream into. | The value of the `project_id` in the credentials file |
 | customer\_id | The customer id to identify the tenant of Google Chronicle to stream into. The value of the `customer_id` should be specified in the configuration file. |  |
-| log\_type | The log type to handle the request entries. Users must set up the valid log types and here is [the supported log types](https://cloud.google.com/chronicle/docs/ingestion/parser-list/supported-default-parsers). Otherwise, the chronicle service denies to handle the ingested logs. |  |
+| log\_type | The log type to parse logs as. Google Chronicle supports parsing for [specific log types only](https://cloud.google.com/chronicle/docs/ingestion/parser-list/supported-default-parsers). |  |
 | region | The GCP region in which to store security logs. Currently, there are several supported regions: `US`, `EU`, `UK`, `ASIA`. Blank is handled as `US`.   |  |
-| log\_key | By default, the whole log record will be sent to Chronocle. If you specify a key name with this option, then only the value of that key will be sent to Chronicle. | |
+| log\_key | By default, the whole log record will be sent to Google Chronicle. If you specify a key name with this option, then only the value of that key will be sent to Google Chronicle. | |
 
-See Google's [official documentation](https://cloud.google.com/chronicle/docs/reference/ingestion-api)) for further details.
+See Google's [official documentation](https://cloud.google.com/chronicle/docs/reference/ingestion-api) for further details.
 
 ## Configuration File
 


### PR DESCRIPTION
Minor re-wording and typo fixes for the Chronicle plugin.